### PR TITLE
use a single sliding transform, add `touching` and `metadata, deprecate `immediatelyFollowsPrevious`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+/dist
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ or
   type="text/javascript"
   src="https://cdn.jsdelivr.net/npm/dynamic-marquee@2"
 ></script>
+
 <script type="text/javascript">
   const Marquee = dynamicMarquee.Marquee;
 </script>
@@ -84,16 +85,20 @@ if (marquee.isWaitingForItem()) {
 }
 ```
 
+`appendItem` also takes an optional second param `config` object, which should contain a `metadata` property. The value of this will be provided back to you in `onItemRequired`.
+
 You can be notified when an item is required with
 
 ```js
-marquee.onItemRequired(({ immediatelyFollowsPrevious }) => {
-  // for convenience if you have an item ready to go you can just return it
+marquee.onItemRequired(({ touching }) => {
+  // For convenience if you have an item ready to go you can just return it
   // in place of `marquee.appendItem($item);`
 
-  // if `immediatelyFollowsPrevious` is `true`, this would be a good time to add
-  // a seperator on the side that is entering the screen first. See loop.js
-  // for an example.
+  // If the new item would be touching another then `touching`
+  // will be set to an object that contains `$el` and `metadata` of
+  // the item it will be touching.
+  // This can be used to determine if a separate should be added.
+  // See loop.js for an example.
   return $item;
 });
 ```
@@ -119,6 +124,8 @@ To remove all items call
 ```js
 marquee.clear();
 ```
+
+You should also call this before removing the marquee from the DOM if you no longer need it to ensure that all timers are cleaned up and garbage collection can occur.
 
 ## When has an item been removed?
 

--- a/demo.html
+++ b/demo.html
@@ -48,7 +48,7 @@
         ],
         function () {
           var $separator = document.createElement('div');
-          $separator.innerHTML = '&nbsp|&nbsp';
+          $separator.innerHTML = '&nbsp•&nbsp';
           return $separator;
         }
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/preset-env": "^7.8.7",
         "@rollup/plugin-commonjs": "^21.1.0",
         "@rollup/plugin-node-resolve": "^13.2.1",
+        "@tjenkinson/boundary": "^2.0.0",
         "husky": "^7.0.0",
         "longest-common-substring": "0.0.1",
         "prettier": "^2.0.2",
@@ -1677,6 +1678,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
+    "node_modules/@tjenkinson/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tjenkinson/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-Zq3N32GRAyoTv4IX0OJTwubuwUmEusQEAHHRrgHr5HwEzbqg5EblsZCfjhbdAnDPpIhAWwjTotyattfqV+WDvQ==",
       "dev": true
     },
     "node_modules/@types/estree": {
@@ -3702,6 +3709,12 @@
           "dev": true
         }
       }
+    },
+    "@tjenkinson/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tjenkinson/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-Zq3N32GRAyoTv4IX0OJTwubuwUmEusQEAHHRrgHr5HwEzbqg5EblsZCfjhbdAnDPpIhAWwjTotyattfqV+WDvQ==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/preset-env": "^7.8.7",
     "@rollup/plugin-commonjs": "^21.1.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
+    "@tjenkinson/boundary": "^2.0.0",
     "husky": "^7.0.0",
     "longest-common-substring": "0.0.1",
     "prettier": "^2.0.2",

--- a/src/dynamic-marquee.d.ts
+++ b/src/dynamic-marquee.d.ts
@@ -8,10 +8,23 @@ export type Options = {
 
 export type Item = HTMLElement | string | number;
 
-export class Marquee {
+export type AppendItemConfig<TMetadata> = {
+  metadata?: TMetadata;
+};
+
+export type Touching<TMetadata> = {
+  $el: HTMLElement;
+  metadata: TMetadata;
+};
+
+export class Marquee<TMetadata = null> {
   constructor($container: HTMLElement, options?: Options);
   onItemRequired(
-    callback: (data: { immediatelyFollowsPrevious: boolean }) => Item | void
+    callback: (data: {
+      /** @deprecated use `touching !== null` instead */
+      immediatelyFollowsPrevious: boolean;
+      touching: Touching<TMetadata>;
+    }) => Item | void
   ): void;
   onItemRemoved(callback: ($el: HTMLElement) => void): void;
   onAllItemsRemoved(callback: () => void): void;
@@ -20,7 +33,7 @@ export class Marquee {
   getRate(): number;
   clear(): void;
   isWaitingForItem(): boolean;
-  appendItem($el: Item): void;
+  appendItem($el: Item, config?: AppendItemConfig<TMetadata>): void;
 }
 
 export type LoopBuilder = () => Item;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,3 +21,11 @@ export function toDomEl($el) {
   }
   return $el;
 }
+
+export function last(input) {
+  return input.length ? input[input.length - 1] : null;
+}
+
+export function first(input) {
+  return input.length ? input[0] : null;
+}

--- a/src/loop.js
+++ b/src/loop.js
@@ -10,33 +10,30 @@ export function loop(marquee, buildersIn = [], seperatorBuilder = null) {
     return { builder: builders[nextIndex], index: nextIndex };
   };
 
-  const appendItem = (immediatelyFollowsPrevious) => {
+  const appendItem = (touching) => {
     if (!builders.length || !marquee.isWaitingForItem()) {
       return;
     }
+
+    if (
+      seperatorBuilder &&
+      touching &&
+      touching.metadata?.isSeperator !== true
+    ) {
+      const $el = toDomEl(seperatorBuilder());
+      marquee.appendItem($el, { metadata: { isSeperator: true } });
+      return;
+    }
+
     const { builder, index } = getNextBuilder();
     lastIndex = index;
-    let $item = toDomEl(builder());
-    if (immediatelyFollowsPrevious && seperatorBuilder) {
-      const $seperator = toDomEl(seperatorBuilder());
-      const $container = document.createElement('div');
-      $seperator.style.display = 'inline';
-      $item.style.display = 'inline';
-      if (marquee.getRate() <= 0) {
-        $container.appendChild($seperator);
-        $container.appendChild($item);
-      } else {
-        $container.appendChild($item);
-        $container.appendChild($seperator);
-      }
-      $item = $container;
-    }
-    marquee.appendItem($item);
+    marquee.appendItem(toDomEl(builder()));
   };
-  marquee.onItemRequired(({ immediatelyFollowsPrevious }) =>
-    appendItem(immediatelyFollowsPrevious)
-  );
+
+  marquee.onItemRequired(({ touching }) => appendItem(touching));
+
   appendItem();
+
   return {
     update: (newBuilders) => {
       // try and start from somewhere that makes sense

--- a/src/size-watcher.js
+++ b/src/size-watcher.js
@@ -1,3 +1,12 @@
+const PX_REGEX = /px$/;
+
+function pxStringToValue(input) {
+  if (!PX_REGEX.test(input)) {
+    throw new Error('String missing `px` suffix');
+  }
+  return parseFloat(input.slice(0, -2));
+}
+
 export class SizeWatcher {
   constructor($el) {
     this._$el = $el;
@@ -12,15 +21,27 @@ export class SizeWatcher {
             this._height = size.blockSize;
           })
         : null;
+
     this._observer?.observe($el);
   }
   getWidth() {
-    return this._width ?? this._$el.offsetWidth;
+    if (this._width !== null) return this._width;
+
+    // maps to `inlineSize`
+    const width = pxStringToValue(window.getComputedStyle(this._$el).width);
+    if (this._observer) this._width = width;
+    return width;
   }
   getHeight() {
-    return this._height ?? this._$el.offsetHeight;
+    if (this._height !== null) return this._height;
+
+    // maps to `blockSize`
+    const height = pxStringToValue(window.getComputedStyle(this._$el).height);
+    if (this._observer) this._height = height;
+    return height;
   }
   tearDown() {
     this._observer?.disconnect();
+    this._observer = null;
   }
 }

--- a/src/slider.js
+++ b/src/slider.js
@@ -1,0 +1,51 @@
+import { DIRECTION } from './direction';
+
+const transitionDuration = 30000;
+
+export class Slider {
+  constructor($el, direction) {
+    this._$el = $el;
+    this._direction = direction;
+    this._transitionState = null;
+  }
+
+  setOffset(offset, rate, force) {
+    const transitionState = this._transitionState;
+    const rateChanged = !transitionState || transitionState.rate !== rate;
+    if (transitionState && !force) {
+      const timePassed = performance.now() - transitionState.time;
+      if (timePassed < transitionDuration - 10000 && !rateChanged) {
+        return;
+      }
+    }
+
+    if (force || rateChanged) {
+      if (this._direction === DIRECTION.RIGHT) {
+        this._$el.style.transform = `translateX(${offset}px)`;
+      } else {
+        this._$el.style.transform = `translateY(${offset}px)`;
+      }
+
+      this._$el.style.transition = 'none';
+      this._$el.offsetLeft;
+    }
+
+    if (rate && (force || rateChanged)) {
+      this._$el.style.transition = `transform ${transitionDuration}ms linear`;
+    }
+
+    if (rate) {
+      const futureOffset = offset + (rate / 1000) * transitionDuration;
+      if (this._direction === DIRECTION.RIGHT) {
+        this._$el.style.transform = `translateX(${futureOffset}px)`;
+      } else {
+        this._$el.style.transform = `translateY(${futureOffset}px)`;
+      }
+    }
+
+    this._transitionState = {
+      time: performance.now(),
+      rate,
+    };
+  }
+}


### PR DESCRIPTION
A big refactor that switches to having all items remains static and the container slide using transform. This should make it impossible for items to drift and overlap each other.

It also provides a bit more info in the `onItemRequired` callback in a new `touching` property, which means that adding a separator can be more accurate. Previously with the `loop` helper if you changed direction you could end up with 2 separators touching each other, which is no longer the case. 