### PR TITLE
make sure items have a width for `upDown` mode

### DIFF
--- a/src/item.js
+++ b/src/item.js
@@ -11,6 +11,9 @@ export class Item {
     $container.style.padding = '0';
     if (direction === DIRECTION.RIGHT) {
       $container.style.whiteSpace = 'nowrap';
+    } else {
+      $container.style.left = '0';
+      $container.style.right = '0';
     }
     this._sizeWatcher = new SizeWatcher($container);
     $container.appendChild($el);


### PR DESCRIPTION
Without this change when you make the item a block element by default it will have width 0 because the container has width 0

Interestingly text in the element would bump up the width until it filled the container size, but if you left the element empty with `width: 100%` it would have width 0

Fixes #435