### PR TITLE
react to item size shrinking as well as growing

### DIFF
--- a/src/marquee.js
+++ b/src/marquee.js
@@ -366,9 +366,7 @@ export class Marquee {
       }
 
       this._items.reduce((newOffset, item) => {
-        if (newOffset !== null && item.offset < newOffset) {
-          // the size of the item before has increased and would now be overlapping
-          // this one, so shuffle this one along
+        if (newOffset !== null) {
           item.offset = newOffset;
         }
         item.item.setOffset(item.offset);


### PR DESCRIPTION
Without this change if the contents of an item gets bigger, the remaining items move. If an item shrinks though, there is a gap.