### PR TITLE
added `snapToNeighbour` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ if (marquee.isWaitingForItem()) {
 }
 ```
 
-`appendItem` also takes an optional second param `config` object, which should contain a `metadata` property. The value of this will be provided back to you in `onItemRequired`.
+`appendItem` also takes an optional second param `config` object, which can contain:
+
+- `metadata`: The value of this will be provided back to you in `onItemRequired`.
+- `snapToNeighbour`: If `true` the item will snap to the end of the neighbouring item instead of starting off screen.
 
 You can be notified when an item is required with
 

--- a/src/dynamic-marquee.d.ts
+++ b/src/dynamic-marquee.d.ts
@@ -10,6 +10,7 @@ export type Item = HTMLElement | string | number;
 
 export type AppendItemConfig<TMetadata> = {
   metadata?: TMetadata;
+  snapToNeighbour?: boolean;
 };
 
 export type Touching<TMetadata> = {

--- a/src/item.js
+++ b/src/item.js
@@ -2,7 +2,7 @@ import { DIRECTION } from './direction.js';
 import { SizeWatcher } from './size-watcher.js';
 
 export class Item {
-  constructor($el, direction, metadata, onSizeChange) {
+  constructor($el, direction, metadata, snapToNeighbor, onSizeChange) {
     const $container = document.createElement('div');
     $container.style.all = 'unset';
     $container.style.display = 'block';
@@ -21,6 +21,7 @@ export class Item {
     this._$el = $el;
     this._direction = direction;
     this._metadata = metadata;
+    this._snapToNeighbor = snapToNeighbor;
     this._offset = null;
   }
   getSize({ inverse = false } = {}) {
@@ -55,5 +56,8 @@ export class Item {
   }
   getMetadata() {
     return this._metadata;
+  }
+  getSnapToNeighbor() {
+    return this._snapToNeighbor;
   }
 }


### PR DESCRIPTION
You can now pass a `snapToNeighbour: true` when calling `appendItem`, which will cause the new item to snap to the neighbour instead of starting of screen.